### PR TITLE
Enable delegated admin for AWS Identity Center

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -5,6 +5,7 @@
         "enterprise_sso_deployment_account_id": "123456789012",
         "enterprise_sso_management_read_only_role": "assignment-management-read-only-role",
         "enterprise_sso_management_role": "assignment-management-role",
+        "enterprise_sso_use_delegated_admin": false,
         "target_event_bus_name": "enterprise-aws-sso",
         "target_event_bus_region": "eu-central-1",
         "assignment_definition_table_partition_key": "mappingId",

--- a/cdk.context.json
+++ b/cdk.context.json
@@ -5,7 +5,6 @@
         "enterprise_sso_deployment_account_id": "123456789012",
         "enterprise_sso_management_read_only_role": "assignment-management-read-only-role",
         "enterprise_sso_management_role": "assignment-management-role",
-        "enterprise_sso_use_delegated_admin": false,
         "target_event_bus_name": "enterprise-aws-sso",
         "target_event_bus_region": "eu-central-1",
         "assignment_definition_table_partition_key": "mappingId",

--- a/deployment/enterprise_sso/enterprise_aws_sso_management_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_management_stack.py
@@ -82,6 +82,14 @@ class EnterpriseAwsSsoManagementStack(Stack):
                         resources=["*"],
                     ),
                     iam.PolicyStatement(
+                        sid="ListDelegatedAdministrators",
+                        actions=[
+                            "organizations:ListDelegatedAdministrators",
+                        ],
+                        effect=iam.Effect.ALLOW,
+                        resources=["*"],
+                    ),
+                    iam.PolicyStatement(
                         sid="IAMListPermissions",
                         actions=["iam:ListRoles", "iam:ListPolicies"],
                         effect=iam.Effect.ALLOW,

--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -211,7 +211,7 @@ class EnterpriseAwsSsoExecStack(Stack):
                     sid="AllowPublishingToSns",
                     actions=["sns:Publish"],
                     effect=iam.Effect.ALLOW,
-                    resources=["*"],
+                    resources=[self.error_notification_topic.topic_arn],
                 ),
             ]
         )

--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -23,7 +23,6 @@ class EnterpriseAwsSsoExecStack(Stack):
         management_account_id: str = context.get("enterprise_sso_management_account_id")
         sso_exec_account_id: str = context.get("enterprise_sso_exec_account_id")
         deployment_account_id: str = context.get("enterprise_sso_deployment_account_id")
-        use_delegated_admin: bool = context.get("enterprise_sso_use_delegated_admin")
         error_notification_email: str = context.get("error_notifications_email")
         sso_management_read_only_role: str = context.get(
             "enterprise_sso_management_read_only_role",
@@ -209,35 +208,10 @@ class EnterpriseAwsSsoExecStack(Stack):
                     resources=["*"],
                 ),
                 iam.PolicyStatement(
-                    sid="IAMListPermissions",
-                    actions=["iam:ListRoles", "iam:ListPolicies"],
+                    sid="AllowPublishingToSns",
+                    actions=["sns:Publish"],
                     effect=iam.Effect.ALLOW,
                     resources=["*"],
-                ),
-                iam.PolicyStatement(
-                    sid="AccessToSSOProvisionedRoles",
-                    actions=[
-                        "iam:AttachRolePolicy",
-                        "iam:CreateRole",
-                        "iam:DeleteRole",
-                        "iam:DeleteRolePolicy",
-                        "iam:DetachRolePolicy",
-                        "iam:GetRole",
-                        "iam:ListAttachedRolePolicies",
-                        "iam:ListRolePolicies",
-                        "iam:PutRolePolicy",
-                        "iam:UpdateRole",
-                        "iam:UpdateRoleDescription",
-                    ],
-                    effect=iam.Effect.ALLOW,
-                    resources=[
-                        "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*"],
-                ),
-                iam.PolicyStatement(
-                    actions=["iam:GetSAMLProvider"],
-                    effect=iam.Effect.ALLOW,
-                    resources=[
-                        "arn:aws:iam::*:saml-provider/AWSSSO_*_DO_NOT_DELETE"],
                 ),
             ]
         )
@@ -475,7 +449,6 @@ class EnterpriseAwsSsoExecStack(Stack):
                 "ASSOCIATIONID_CONCAT_CHAR": "|",
                 "SSO_ADMIN_ROLE_ARN": f"arn:aws:iam::{management_account_id}:role/{sso_management_role}",
                 "MANAGEMENT_ACCOUNT_ID": management_account_id,
-                "USE_DELEGATED_ADMIN": use_delegated_admin,
             },
         )
 

--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -195,7 +195,7 @@ class EnterpriseAwsSsoExecStack(Stack):
         )
 
         ## Assignment management role for assignment execution function ##
-        assignment_management_policy = iam.PolicyDocument(
+        assignment_exec_policy = iam.PolicyDocument(
             statements=[
                 iam.PolicyStatement(
                     actions=[
@@ -237,7 +237,7 @@ class EnterpriseAwsSsoExecStack(Stack):
             role_id="AssignmentExecRole",
             role_name=sso_management_role,
             inline_policies={
-                "assignment-policy": assignment_management_policy,
+                "assignment-policy": assignment_exec_policy,
             },
             managed_policy_name_list=[
                 "service-role/AWSLambdaSQSQueueExecutionRole",

--- a/src/functions/assignment_execution_handler/index.py
+++ b/src/functions/assignment_execution_handler/index.py
@@ -31,7 +31,7 @@ LAMBDA_FUNC_NAME = "Assignment execution handler"
 session = boto3.Session()
 
 
-# Proper error hanlder class
+# Proper error handler class
 sns_arn = os.getenv(
     "ERROR_TOPIC_NAME", "ERROR_TOPIC_NAME"
 )  # Getting the SNS Topic ARN passed in by the environment variables.
@@ -45,20 +45,26 @@ error_handler = Error(
 logger = error_handler.get_logger()
 
 
+# Is Identity Center delegated admin?
+use_delegated_admin = os.getenv("USE_DELEGATED_ADMIN", False)
+
 # Get SSO Instance
+sso_delegated_admin = None
+
+# Get SSO Instance
+management_account_id = os.getenv("MANAGEMENT_ACCOUNT_ID", "012345678901")
 sso_admin_role_arn = os.getenv(
     "SSO_ADMIN_ROLE_ARN",
     "arn:aws:iam::112223334444:role/assignment-management-role",
 )
-assumed_role_session = assume_role(session, sso_admin_role_arn)
-sso = None
+assumed_admin_role_session = assume_role(session, sso_admin_role_arn)
+sso_admin = None
 
 
 def handler(event, context):
     # TODO make proper call outside handler work with tests
-    global sso
-    if sso == None:
-        sso = SsoService(assumed_role_session)
+    global sso_admin
+    global sso_delegated_admin
 
     for record in event["Records"]:
         message = record["body"]
@@ -69,6 +75,16 @@ def handler(event, context):
         permission_set_arn = messageDict["PermissionSetArn"]
         target_id = messageDict["TargetId"]
         action = messageDict["Action"]
+
+        # For management account and none delegated admin, we use the management account
+        if target_id == management_account_id or not use_delegated_admin:
+            if sso_admin is None:
+                sso_admin = SsoService(assumed_admin_role_session)
+            sso = sso_admin
+        else:
+            if sso_delegated_admin is None:
+                sso_delegated_admin = SsoService(session)
+            sso = sso_delegated_admin
 
         if action == ACTION_TYPE_CREATE:
             # Create Account/PermissionSet Assignment
@@ -89,7 +105,7 @@ def handler(event, context):
                 # If Exception occurs, parse Response and write it to Error Topic.
                 # Then, raise exception to not delete the message from queue.
                 logger.error("Exception: " + str(exception))
-                error_halnder.publish_error_message(message, str(exception))
+                error_handler.publish_error_message(message, str(exception))
                 raise (exception)
 
         elif action == ACTION_TYPE_DELETE:
@@ -108,13 +124,14 @@ def handler(event, context):
                 # If Exception occurs, parse Response and write it to Error Topic.
                 # Then, raise exception to not delete the message from queue.
                 logger.error("Exception: " + str(exception))
-                error_halnder.publish_error_message(message, str(exception))
+                error_handler.publish_error_message(message, str(exception))
                 raise (exception)
 
         else:
             # Not supported action
             logger.info("Not supported action: " + str(message))
-            error_halnder.publish_error_message(message, "Not supported action.")
+            error_handler.publish_error_message(
+                message, "Not supported action.")
             raise AttributeError
 
     return {


### PR DESCRIPTION
*Description of changes:*
This change allows to use the delegated administrator for AWS Identity Center. This means if delegated admin is configured the following will happen:

- If the target account is the management account: create the account assignment in the management account
- For all the other accounts: create the account assignment in the delegated admin account

*Additional Fixes*

- Added `sns:Publish` permission to the `AssignmentExecRole` in the deployment account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
