### PR TITLE
Fixing runtime errors

### DIFF
--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -269,7 +269,7 @@ class EnterpriseAwsSsoExecStack(Stack):
                     command=[
                         "bash",
                         "-c",
-                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{os.path.basename(common_layer_path)}/",
+                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{common_layer_path.name}/",
                     ],
                 ),
             ),
@@ -287,7 +287,7 @@ class EnterpriseAwsSsoExecStack(Stack):
                     command=[
                         "bash",
                         "-c",
-                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{os.path.basename(orgz_layer_path)}/",
+                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{orgz_layer_path.name}/",
                     ],
                 ),
             ),
@@ -305,7 +305,7 @@ class EnterpriseAwsSsoExecStack(Stack):
                     command=[
                         "bash",
                         "-c",
-                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{os.path.basename(sso_layer_path)}/",
+                        f"pip --no-cache-dir install -r requirements.txt -t /asset-output/python && cp -au . /asset-output/python/{sso_layer_path.name}/",
                     ],
                 ),
             ),
@@ -541,7 +541,7 @@ class LocalBundler:
                 else:
                     shutil.copy2(source_item, destination_item)
 
-        destination_layer_folder = Path(python_output_dir, os.path.basename(self.source_root))
+        destination_layer_folder = Path(python_output_dir, self.source_root.name)
 
         destination_layer_folder.mkdir()
 

--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -264,7 +264,7 @@ class EnterpriseAwsSsoExecStack(Stack):
             code=_lambda.Code.from_asset(
                 path=str(common_layer_path),
                 bundling=BundlingOptions(
-                    local=LocalBundler(str(common_layer_path)),
+                    local=LocalBundler(str(common_layer_path), "common"),
                     image=lambda_runtime.bundling_image,
                     command=[
                         "bash",
@@ -282,7 +282,7 @@ class EnterpriseAwsSsoExecStack(Stack):
             code=_lambda.Code.from_asset(
                 path=str(orgz_layer_path),
                 bundling=BundlingOptions(
-                    local=LocalBundler(str(orgz_layer_path)),
+                    local=LocalBundler(str(orgz_layer_path), "orgz"),
                     image=lambda_runtime.bundling_image,
                     command=[
                         "bash",
@@ -300,7 +300,7 @@ class EnterpriseAwsSsoExecStack(Stack):
             code=_lambda.Code.from_asset(
                 path=str(sso_layer_path),
                 bundling=BundlingOptions(
-                    local=LocalBundler(str(sso_layer_path)),
+                    local=LocalBundler(str(sso_layer_path), "sso"),
                     image=lambda_runtime.bundling_image,
                     command=[
                         "bash",
@@ -508,8 +508,9 @@ class EnterpriseAwsSsoExecStack(Stack):
 class LocalBundler:
     """This allows packaging lambda functions without the use of Docker"""
 
-    def __init__(self, source_root):
+    def __init__(self, source_root, module_path):
         self.source_root = source_root
+        self.module_path = module_path
 
     def try_bundle(self, output_dir: str, options: BundlingOptions) -> bool:
         try:
@@ -533,6 +534,7 @@ class LocalBundler:
         )
 
         def copytree(src: str, dst: str, symlinks=False, ignore=None):
+            os.mkdir(dst)
             for item in os.listdir(src):
                 source_item = os.path.join(src, item)
                 destination_item = os.path.join(dst, item)
@@ -541,6 +543,6 @@ class LocalBundler:
                 else:
                     shutil.copy2(source_item, destination_item)
 
-        copytree(self.source_root, python_output_dir)
+        copytree(self.source_root, str(Path(python_output_dir, self.module_path)))
 
         return True

--- a/src/functions/assignment_execution_handler/index.py
+++ b/src/functions/assignment_execution_handler/index.py
@@ -117,7 +117,7 @@ def handler(event, context):
         if action == ACTION_TYPE_CREATE:
 
             @backoff.on_exception(
-                backoff.full_jitter,
+                backoff.expo,
                 (
                     sso.client.exceptions.ConflictException,
                     sso.client.exceptions.ThrottlingException,
@@ -152,7 +152,7 @@ def handler(event, context):
         elif action == ACTION_TYPE_DELETE:
 
             @backoff.on_exception(
-                backoff.full_jitter,
+                backoff.expo,
                 (
                     sso.client.exceptions.ConflictException,
                     sso.client.exceptions.ThrottlingException,


### PR DESCRIPTION
*Description of changes:*
With the latest changes, two errors were introduced. With this version, these two errors are fixed:

<details>
<summary><b>The backoff decorator, had still the wrong wait generator</b></summary>

```
[ERROR] TypeError: full_jitter() missing 1 required positional argument: 'value'
Traceback (most recent call last):
  File "/var/task/index.py", line 150, in handler
    raise (exception)
  File "/var/task/index.py", line 142, in handler
    create_account_assignment(
  File "/opt/python/backoff/_sync.py", line 92, in retry
    wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
  File "/opt/python/backoff/_common.py", line 29, in _init_wait_gen
    initialized = wait_gen(**kwargs)
```

</details>

<details>
<summary><b>The local layer generation now creates a new folder with the layer name</b></summary>

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'index': No module named 'common'
Traceback (most recent call last):
```

</details>


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
