### PR TITLE
don't crash when no principals found

### DIFF
--- a/src/functions/assignment_execution_handler/index.py
+++ b/src/functions/assignment_execution_handler/index.py
@@ -72,9 +72,10 @@ def handler(event, context):
     # check if delegated admin is enabled
     if use_delegated_admin is None:
         try:
-            response = assumed_admin_role_session.client(
+            org_client = assumed_admin_role_session.client(
                 "organizations"
-            ).list_delegated_administrators(
+            )
+            response = org_client.list_delegated_administrators(
                 ServicePrincipal="sso.amazonaws.com",
             )
             logger.info(response)

--- a/src/functions/assignment_execution_handler/test/payloads.py
+++ b/src/functions/assignment_execution_handler/test/payloads.py
@@ -8,7 +8,7 @@ event_input_data_create = {
         {
             "messageId": "3769c1ec-6f65-49c1-966c-2be7732a0a1d",
             "receiptHandle": "AQEBZEJDt7kCNhTtZzI5/WCH4E7ArTzudBiU3u1IAystrGA9yx3wAg223Pg9xY6yBEXExnmW+PkcUbGJpfSvKaapgbidiBRHhNFCsSMOGGg0FFwkcwNo7WoN6xtLrQh+x+Vm6Rx/jvTupYN7lGFvUDHSgby25FTiLcMN3bBG8pbMShiFhe4RXK4hO0Gc/0gcq2rbj1INNUfm37KJa0v5KQqbHyAKXQ4WaaKkmRsuE//2OjFBqvqW3x2TBQ6YUtc576O2F0fm7kuB16ieNIyQQ7xRlfsjPXsQ4wZKKpjHqg0zfjBMeopENz762wAbFFxcaA1tqB5jcstuoL8DGSjFEFWtYkyUjNIzrtM3ttv3nx021MrDbXqQFw3egvoHPjg9p9ytpceakdb+6N3LgQ6cHXR6FQ==",
-            "body": '{"PrincipalType": "string", "PrincipalId":"string","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb","TargetId":"string", "Action":"CREATE"}',
+            "body": '{"PrincipalType": "string", "PrincipalId":"string","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb","TargetId":"dj358s9nldve", "Action":"CREATE"}',
             "attributes": {
                 "ApproximateReceiveCount": "1",
                 "SentTimestamp": "1626440153145",
@@ -29,7 +29,7 @@ event_input_data_delete = {
         {
             "messageId": "3769c1ec-6f65-49c1-966c-2be7732a0a1d",
             "receiptHandle": "AQEBZEJDt7kCNhTtZzI5/WCH4E7ArTzudBiU3u1IAystrGA9yx3wAg223Pg9xY6yBEXExnmW+PkcUbGJpfSvKaapgbidiBRHhNFCsSMOGGg0FFwkcwNo7WoN6xtLrQh+x+Vm6Rx/jvTupYN7lGFvUDHSgby25FTiLcMN3bBG8pbMShiFhe4RXK4hO0Gc/0gcq2rbj1INNUfm37KJa0v5KQqbHyAKXQ4WaaKkmRsuE//2OjFBqvqW3x2TBQ6YUtc576O2F0fm7kuB16ieNIyQQ7xRlfsjPXsQ4wZKKpjHqg0zfjBMeopENz762wAbFFxcaA1tqB5jcstuoL8DGSjFEFWtYkyUjNIzrtM3ttv3nx021MrDbXqQFw3egvoHPjg9p9ytpceakdb+6N3LgQ6cHXR6FQ==",
-            "body": '{"PrincipalType": "string", "PrincipalId":"string","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb","TargetId":"string", "Action":"DELETE"}',
+            "body": '{"PrincipalType": "string", "PrincipalId":"string","PermissionSetArn":"arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb","TargetId":"dj358s9nldve", "Action":"DELETE"}',
             "attributes": {
                 "ApproximateReceiveCount": "1",
                 "SentTimestamp": "1626440153145",

--- a/src/functions/assignment_execution_handler/test/test_assignment_execution_handler.py
+++ b/src/functions/assignment_execution_handler/test/test_assignment_execution_handler.py
@@ -36,14 +36,16 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
     sso = sso_layer_mock.test_0_sso_list_instances()
 
     # Adding mocked SSO layer to lambda function
-    index.sso = sso
-    index.sso.client = sso_admin
+    index.sso_admin = sso
+    index.sso_admin.client = sso_admin
 
+    index.use_delegated_admin = False
     """
     Assignment execution create event test
     """
 
     def test_0_handler_assignment_execution_handler_create_success(self):
+
         self.sso_admin_stubber.add_response(
             "create_account_assignment",
             service_response={
@@ -53,10 +55,10 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
                     "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb",
                     "PrincipalId": "string",
                     "PrincipalType": "string",
-                    "RequestId": "string",
+                    "RequestId": "h47hd9w5i0tv4x1q55f664arbe4ab2otges4",
                     "Status": "string",
-                    "TargetId": "string",
-                    "TargetType": "string",
+                    "TargetId": "dj358s9nldve",
+                    "TargetType": "AWS_ACCOUNT",
                 }
             },
             expected_params={
@@ -64,7 +66,7 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
                 "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb",
                 "PrincipalId": "string",
                 "PrincipalType": "string",
-                "TargetId": "string",
+                "TargetId": "dj358s9nldve",
                 "TargetType": "AWS_ACCOUNT",
             },
         )
@@ -80,7 +82,7 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
     """
 
     def test_1_handler_assignment_execution_handler_delete_success(self):
-        index.sso.client = self.sso_admin
+        index.sso_admin.client = self.sso_admin
 
         self.sso_admin_stubber.add_response(
             "delete_account_assignment",
@@ -91,9 +93,9 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
                     "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb",
                     "PrincipalId": "string",
                     "PrincipalType": "string",
-                    "RequestId": "string",
+                    "RequestId": "h47hd9w5i0tv4x1q55f664arbe4ab2otges4",
                     "Status": "string",
-                    "TargetId": "string",
+                    "TargetId": "dj358s9nldve",
                     "TargetType": "string",
                 }
             },
@@ -102,7 +104,7 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
                 "PermissionSetArn": "arn:aws:sso:::permissionSet/ssoins-7223ac639f55e492/ps-504d6c2b57a3f2cb",
                 "PrincipalId": "string",
                 "PrincipalType": "string",
-                "TargetId": "string",
+                "TargetId": "dj358s9nldve",
                 "TargetType": "AWS_ACCOUNT",
             },
         )


### PR DESCRIPTION
Fixed a bug when the rules reference a principal that doesn't exist in the identity store.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
