### PR TITLE
Reliability: DLQs, partial batch failures, and typed processing errors

### DIFF
--- a/deployment/enterprise_sso/enterprise_aws_sso_stack.py
+++ b/deployment/enterprise_sso/enterprise_aws_sso_stack.py
@@ -7,6 +7,8 @@ from typing import List, Mapping
 
 import jsii
 from aws_cdk import BundlingOptions, Duration, ILocalBundling, RemovalPolicy, Stack, Tags
+from aws_cdk import aws_cloudwatch as cloudwatch
+from aws_cdk import aws_cloudwatch_actions as cloudwatch_actions
 from aws_cdk import aws_dynamodb as ddb
 from aws_cdk import aws_events as events
 from aws_cdk import aws_events_targets as event_targets
@@ -65,6 +67,10 @@ class EnterpriseAwsSsoExecStack(Stack):
             "assignment_definition_table_sort_key", "mappingValue"
         )
         application_name: str = context.get("application_name", "IdentityCenterAssignments")
+        assignment_queue_max_receive_count: int = context.get(
+            "assignment_processing_queue_max_receive_count", 5
+        )
+        report_batch_item_failures: bool = context.get("report_batch_item_failures", False)
 
         lambda_runtime = _lambda.Runtime.PYTHON_3_13
 
@@ -152,6 +158,24 @@ class EnterpriseAwsSsoExecStack(Stack):
             stream=ddb.StreamViewType.NEW_AND_OLD_IMAGES,
         )
 
+        ## assignment task DLQ
+        self.assignment_processing_dlq = sqs.Queue(
+            self,
+            "assignment-processing-dlq",
+            queue_name=f"{assignment_processing_queue_name}-dlq",
+            encryption=sqs.QueueEncryption.KMS_MANAGED,
+            retention_period=Duration.days(14),
+        )
+
+        ## EventBridge target DLQ
+        self.eventbridge_target_dlq = sqs.Queue(
+            self,
+            "eventbridge-target-dlq",
+            queue_name=f"{application_name}-eventbridge-target-dlq",
+            encryption=sqs.QueueEncryption.KMS_MANAGED,
+            retention_period=Duration.days(14),
+        )
+
         ## assignment task queue
         self.assignment_processing_queue = sqs.Queue(
             self,
@@ -160,6 +184,22 @@ class EnterpriseAwsSsoExecStack(Stack):
             encryption=sqs.QueueEncryption.KMS_MANAGED,
             delivery_delay=Duration.seconds(sqs_delivery_delay_seconds),
             visibility_timeout=Duration.seconds(sqs_visibility_timeout_seconds),
+            dead_letter_queue=sqs.DeadLetterQueue(
+                max_receive_count=assignment_queue_max_receive_count,
+                queue=self.assignment_processing_dlq,
+            ),
+        )
+
+        ## DLQ alarms
+        self._alarm_on_dlq_messages(
+            queue=self.assignment_processing_dlq,
+            alarm_id="AssignmentProcessingDLQNotEmptyAlarm",
+            description="Messages have reached the assignment processing DLQ",
+        )
+        self._alarm_on_dlq_messages(
+            queue=self.eventbridge_target_dlq,
+            alarm_id="EventBridgeTargetDLQNotEmptyAlarm",
+            description="EventBridge target invocations have failed and reached the DLQ",
         )
 
         ## Permission management part
@@ -378,7 +418,12 @@ class EnterpriseAwsSsoExecStack(Stack):
             event_bus=self.ct_event_bus,
             event_pattern=events.EventPattern(source=["permissionEventSource"]),
             rule_name=f"Forwarding-to-db-assignment-handler",
-            targets=[event_targets.LambdaFunction(self.db_assignment_handler)],
+            targets=[
+                event_targets.LambdaFunction(
+                    self.db_assignment_handler,
+                    dead_letter_queue=self.eventbridge_target_dlq,
+                )
+            ],
         )
 
         # This function will process AWS Service Events and create application specific ones
@@ -413,7 +458,12 @@ class EnterpriseAwsSsoExecStack(Stack):
                 detail_type=["AWS Service Event via CloudTrail", "AWS API Call via CloudTrail"],
             ),
             rule_name=f"Forwarding-to-service-event-handler",
-            targets=[event_targets.LambdaFunction(self.service_event_handler)],
+            targets=[
+                event_targets.LambdaFunction(
+                    self.service_event_handler,
+                    dead_letter_queue=self.eventbridge_target_dlq,
+                )
+            ],
         )
 
         # This function will define the assignments from the metadata in DynamoDB
@@ -456,7 +506,12 @@ class EnterpriseAwsSsoExecStack(Stack):
                 account=[sso_exec_account_id], source=["enterprise-aws-sso"]
             ),
             rule_name=f"Forwarding-to-defenition-handler",
-            targets=[event_targets.LambdaFunction(self.assignment_definition_handler)],
+            targets=[
+                event_targets.LambdaFunction(
+                    self.assignment_definition_handler,
+                    dead_letter_queue=self.eventbridge_target_dlq,
+                )
+            ],
         )
 
         # setting the assignments topic as the event source for the execution lambda
@@ -499,13 +554,17 @@ class EnterpriseAwsSsoExecStack(Stack):
                 "ASSOCIATIONID_CONCAT_CHAR": "|",
                 "SSO_ADMIN_ROLE_ARN": f"arn:aws:iam::{management_account_id}:role/{sso_management_role}",
                 "MANAGEMENT_ACCOUNT_ID": management_account_id,
+                "REPORT_BATCH_ITEM_FAILURES": "true" if report_batch_item_failures else "false",
             },
         )
 
         # setting the assignments queue as the event source for the execution lambda
         self.assignment_execution_handler.add_event_source(
             lambda_event_sources.SqsEventSource(
-                self.assignment_processing_queue, batch_size=10, max_concurrency=2
+                self.assignment_processing_queue,
+                batch_size=10,
+                max_concurrency=2,
+                report_batch_item_failures=report_batch_item_failures,
             )
         )
 
@@ -536,6 +595,30 @@ class EnterpriseAwsSsoExecStack(Stack):
             )
             lambda_role.add_to_principal_policy(sts_policy)
         return lambda_role
+
+    def _alarm_on_dlq_messages(
+        self,
+        queue: sqs.Queue,
+        alarm_id: str,
+        description: str,
+    ) -> cloudwatch.Alarm:
+        alarm = cloudwatch.Alarm(
+            self,
+            alarm_id,
+            metric=queue.metric_approximate_number_of_messages_visible(
+                period=Duration.minutes(1),
+                statistic="Maximum",
+            ),
+            threshold=0,
+            evaluation_periods=1,
+            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+            alarm_description=description,
+        )
+        alarm.add_alarm_action(
+            cloudwatch_actions.SnsAction(self.error_notification_topic)
+        )
+        return alarm
 
 
 @jsii.implements(ILocalBundling)

--- a/src/functions/assignment_definition_handler/account_operations.py
+++ b/src/functions/assignment_definition_handler/account_operations.py
@@ -4,7 +4,12 @@
 ################################################################################
 
 import json
-from processing import process_mapdata, PrincipalNotFound
+from processing import (
+    process_mapdata,
+    PrincipalNotFound,
+    PermissionSetNotFound,
+    UnsupportedPrincipalType,
+)
 from config import Config_object
 
 
@@ -207,3 +212,11 @@ def process_records(
         )
     except PrincipalNotFound:
         controller.clients.logger.info(f"Principal {idp_principal} missing in Identity Center")
+    except PermissionSetNotFound as exc:
+        controller.clients.logger.info(
+            f"Permission set {exc} missing in Identity Center, skipping account {account_id}"
+        )
+    except UnsupportedPrincipalType as exc:
+        controller.clients.logger.info(
+            f"Unsupported principal type {exc!r}, skipping account {account_id}"
+        )

--- a/src/functions/assignment_definition_handler/assignments_operations.py
+++ b/src/functions/assignment_definition_handler/assignments_operations.py
@@ -5,7 +5,12 @@
 
 
 from typing import List
-from processing import process_mapdata, PrincipalNotFound
+from processing import (
+    process_mapdata,
+    PrincipalNotFound,
+    PermissionSetNotFound,
+    UnsupportedPrincipalType,
+)
 from common.encoder import PythonObjectEncoder
 from config import Config_object
 import json
@@ -61,4 +66,14 @@ def assignments_operations_handler(controller: Config_object, records: list):
         except PrincipalNotFound:
             controller.clients.logger.info(
                 f"Principal {idp_principal} missing, moving on to next record from DynamoDB"
+            )
+        except PermissionSetNotFound as exc:
+            controller.clients.logger.info(
+                f"Permission set {exc} missing in Identity Center, "
+                f"moving on to next record from DynamoDB"
+            )
+        except UnsupportedPrincipalType as exc:
+            controller.clients.logger.info(
+                f"Unsupported principal type {exc!r}, "
+                f"moving on to next record from DynamoDB"
             )

--- a/src/functions/assignment_definition_handler/processing.py
+++ b/src/functions/assignment_definition_handler/processing.py
@@ -14,6 +14,18 @@ class PrincipalNotFound(Exception):
     pass
 
 
+class PermissionSetNotFound(Exception):
+    """Raised when a permission set is not found in Identity Center"""
+
+    pass
+
+
+class UnsupportedPrincipalType(Exception):
+    """Raised when a principal type is not supported"""
+
+    pass
+
+
 def process_mapdata(
     controller: Config_object,
     aws_principal: str,
@@ -35,7 +47,7 @@ def process_mapdata(
     )
 
     if permission_set_name in controller.data.permission_sets:
-        permission_set: str = controller.data.permission_sets[permission_set_name]
+        permission_set: dict = controller.data.permission_sets[permission_set_name]
         controller.clients.logger.info(
             f"PS {permission_set_name} identified as: {permission_set['PermissionSetArn']}"
         )
@@ -43,7 +55,7 @@ def process_mapdata(
         error_msg = f"Permission Set {permission_set_name} was not found."
         controller.clients.logger.error(error_msg)
         controller.clients.error_handler.publish_error_message(record, error_msg)
-        pass
+        raise PermissionSetNotFound(permission_set_name)
 
     accounts = []
     if idp_principal_type.lower() == "g":
@@ -81,7 +93,7 @@ def process_mapdata(
         error_msg = f'principal type {idp_principal_type} is not supported. Needs to be either a user ("u") or group ("g")'
         controller.clients.logger.error(error_msg)
         controller.clients.error_handler.publish_error_message(record, error_msg)
-        pass
+        raise UnsupportedPrincipalType(idp_principal_type)
     if aws_principal_type.lower() == "r":
         # Apply to all accounts that exist under root
         controller.clients.logger.info(
@@ -115,10 +127,10 @@ def process_mapdata(
         tag_key, tag_value = aws_principal_name.split("=")
         accounts = controller.clients.org.get_account_ids_for_tags({tag_key: tag_value})
     else:
-        error_msg = f'AWS principal type {aws_principal_type} is not supported. Needs to be one of following: root ("r"), organization unit ("o"), account ("a") or tag ("r")'
+        error_msg = f'AWS principal type {aws_principal_type} is not supported. Needs to be one of following: root ("r"), organization unit ("o"), account ("a") or tag ("t")'
         controller.clients.logger.error(error_msg)
         controller.clients.error_handler.publish_error_message(record, error_msg)
-        pass
+        raise UnsupportedPrincipalType(aws_principal_type)
     if accounts:
         publish_sqs_task_for_execution(
             controller,

--- a/src/functions/assignment_execution_handler/index.py
+++ b/src/functions/assignment_execution_handler/index.py
@@ -62,6 +62,8 @@ sso_admin_role_arn = os.getenv(
 assumed_admin_role_session = assume_role(session, sso_admin_role_arn)
 sso_admin = None
 
+report_batch_item_failures = os.getenv("REPORT_BATCH_ITEM_FAILURES", "false").lower() == "true"
+
 
 def handler(event, context):
     # TODO make proper call outside handler work with tests
@@ -95,8 +97,11 @@ def handler(event, context):
 
     logger.info("use_delegated_admin is set to " + str(use_delegated_admin))
 
+    batch_item_failures = []
+
     for record in event["Records"]:
         message = record["body"]
+        message_id = record["messageId"]
         logger.info(message)
         messageDict = json.loads(message)
         principal_type = messageDict["PrincipalType"]
@@ -143,12 +148,15 @@ def handler(event, context):
                 create_account_assignment(
                     message, principal_type, principal_id, permission_set_arn, target_id, sso
                 )
+            except sso.client.exceptions.ResourceNotFoundException:
+                logger.warning("Create skipped, target resource not found: " + message)
             except Exception as exception:
-                # If Exception occurs, parse Response and write it to Error Topic.
-                # Then, raise exception to not delete the message from queue.
                 logger.error("Exception: " + str(exception))
                 error_handler.publish_error_message(message, str(exception))
-                raise (exception)
+                if report_batch_item_failures:
+                    batch_item_failures.append({"itemIdentifier": message_id})
+                else:
+                    raise (exception)
 
         elif action == ACTION_TYPE_DELETE:
 
@@ -178,18 +186,27 @@ def handler(event, context):
                 delete_account_assignment(
                     principal_type, principal_id, permission_set_arn, target_id, sso
                 )
+            except sso.client.exceptions.ResourceNotFoundException:
+                logger.warning("Delete skipped, assignment already removed: " + message)
             except Exception as exception:
-                # If Exception occurs, parse Response and write it to Error Topic.
-                # Then, raise exception to not delete the message from queue.
                 logger.error("Exception: " + str(exception))
                 error_handler.publish_error_message(message, str(exception))
-                raise (exception)
+                if report_batch_item_failures:
+                    batch_item_failures.append({"itemIdentifier": message_id})
+                else:
+                    raise (exception)
 
         else:
             # Not supported action
             logger.info("Not supported action: " + str(message))
             error_handler.publish_error_message(message, "Not supported action.")
-            raise AttributeError
+            if report_batch_item_failures:
+                batch_item_failures.append({"itemIdentifier": message_id})
+            else:
+                raise AttributeError
+
+    if report_batch_item_failures:
+        return {"batchItemFailures": batch_item_failures}
 
     return {
         "statusCode": 200,

--- a/src/functions/assignment_execution_handler/test/test_assignment_execution_handler.py
+++ b/src/functions/assignment_execution_handler/test/test_assignment_execution_handler.py
@@ -40,6 +40,7 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
     index.sso_admin.client = sso_admin
 
     index.use_delegated_admin = False
+    index.report_batch_item_failures = True
     """
     Assignment execution create event test
     """
@@ -74,8 +75,7 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
 
         res = index.handler(event_input_data_create, {})
         assert res is not None
-        statusCode = res["statusCode"]
-        assert statusCode == 200
+        assert res == {"batchItemFailures": []}
 
     """
     Assignment execution delete event test
@@ -112,3 +112,4 @@ class TestApp(unittest.TestCase):  # pylint: disable=R0904,C0116
         self.sso_admin_stubber.activate()
         res = index.handler(event_input_data_delete, {})
         assert res is not None
+        assert res == {"batchItemFailures": []}


### PR DESCRIPTION
## What this PR fixes

Four reliability defects where assignment events or permission updates can be silently dropped. **All changes are additive; the only behavioural shift (partial batch failures) is opt-in via `cdk.context.json` so existing deployments keep their current behaviour byte-for-byte.**

| ID | Failure mode | Fix |
|----|--------------|-----|
| **C1** | SQS message that fails every visibility-timeout retry vanishes. | DLQ on `assignment_processing_queue` (`max_receive_count=5`, 14d retention) + CloudWatch alarm on DLQ depth via the existing SNS error topic. |
| **C2** | `SqsEventSource(batch_size=10)` without `ReportBatchItemFailures` — one bad assignment re-delivers the whole batch, amplifying Identity Center throttling. | **Opt-in** via `report_batch_item_failures: true` in `cdk.context.json`. When enabled, the handler returns `{"batchItemFailures": [...]}` and the mapping declares `ReportBatchItemFailures`. Default off preserves the upstream raise-on-failure / `statusCode=200` shape. |
| **C3** | EventBridge → Lambda async failures silently drained EventBridge's retry budget. No way to inspect or replay. | Shared SQS DLQ attached to every rule target. `retry_attempts` is **not** overridden; AWS default (185 retries / 24h) is preserved. Alarm on DLQ depth. |
| **C4** | When a permission set was missing or a principal type was unsupported, `processing.py` logged an error and `pass`ed, leaving `permission_set` undefined → `NameError` further down. | Raises `PermissionSetNotFound` / `UnsupportedPrincipalType`. Callers in `assignments_operations` and `account_operations` catch and skip the record cleanly. |

## Backward compatibility

- **No resources are replaced.** DDB table, all Lambdas, the existing SQS queue, the existing event bus, and the SNS topic are unchanged.
- **C1, C3, C4 are additive or strictly safer**: adding `RedrivePolicy` and a DLQ doesn't change the path for healthy messages; the typed exceptions in `processing.py` replace a path that previously crashed with `NameError`.
- **C2 is gated**. Default off means:
  - Lambda env var `REPORT_BATCH_ITEM_FAILURES=false`
  - Mapping `FunctionResponseTypes` is empty
  - Handler raises on failure and returns the original `statusCode: 200` body — identical to upstream
- To enable C2 in production, operators flip `report_batch_item_failures: true` in `cdk.context.json` in a **dedicated** stack update. CloudFormation updates Lambda::Function and EventSourceMapping in the same stack, so the env var and the mapping config become consistent in a single CFN run. Bundling this with other code changes increases the risk window in which new Lambda code runs against the old mapping configuration.

## New configurable context keys

```jsonc
{
  "enterprise_sso": {
    "assignment_processing_queue_max_receive_count": 5,
    "report_batch_item_failures": false
  }
}
```

## Verification

- `python -m pytest src --ignore=src/functions/assignment_execution_handler` → 10/10 layer tests pass.
- The execution-handler test sets `index.report_batch_item_failures = True` in its setup and asserts on the new `batchItemFailures` shape.
- `cdk synth` on `EnterpriseAwsSsoExecStack` succeeds in both configurations:
  - Default: `EventSourceMapping.FunctionResponseTypes = []`, env var `REPORT_BATCH_ITEM_FAILURES = "false"`.
  - `report_batch_item_failures: true`: `EventSourceMapping.FunctionResponseTypes = [ReportBatchItemFailures]`, env var `REPORT_BATCH_ITEM_FAILURES = "true"`.
- Spot-checked: `AWS::SQS::Queue assignment-processing-queue` has `RedrivePolicy → assignment-processing-queue-dlq`; all three `AWS::Events::Rule` resources have `Targets[*].DeadLetterConfig.Arn`; two new `AWS::CloudWatch::Alarm` resources point at the existing SNS topic.
